### PR TITLE
Fixed the failure caused by devDependencies or dependencies being undefined

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,7 +6,7 @@ var pkgJson = require(process.cwd() + '/package.json');
 
 function updateDeps(dependencyObject, data) {
 
-    if (!Object.keys(dependencyObject).length) return;
+    if (typeof dependencyObject !== 'object' || !Object.keys(dependencyObject).length) return;
 
     return Object.keys(dependencyObject).reduce(function (prev, key) {
 


### PR DESCRIPTION
Just checking to make sure it is an object before trying to treat it as one. Fixes #2 
